### PR TITLE
fix issue when file has no metadata tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Stems are fun but nobody's releasing them. Stemgen is a way to create your own s
 
 ## Usage
 
+- Clone this repo (downloading instead of cloning loses permissions to execute files)
 - `$ ./stemgen -i track.wav`
 - Have fun! Your new `.stem.m4a` file is in `output` dir
 - Supported input file format are `.wav` `.wave` `.aif` `.aiff` `.flac`

--- a/stemgen
+++ b/stemgen
@@ -80,7 +80,7 @@ create_tags_json() {
 
     echo ${tags[@]}
 
-    jo -p -- "${tags[@]}" > tags.json
+    jo -p -- "${tags[@]:-}" > tags.json
 
     cd ../../
 


### PR DESCRIPTION
If your track has no tags, this command will otherwise hang forever.

The ":-" uses an empty string as the default value in case the tags variable doesn't exists. This changes the command from `jo -p -- ` to `jo -p -- ""`. The first command will hang indefinitely, the latter will echo "{}" to the standard out.

Tested on OSX